### PR TITLE
Remove stop concatenation

### DIFF
--- a/infrastructure/build/fab/lfric_base.py
+++ b/infrastructure/build/fab/lfric_base.py
@@ -25,7 +25,7 @@ from fab.tools import Category
 from fab.util import input_to_output_fpath
 
 from baf_base import BafBase
-from lfric_common import configurator, fparser_workaround_stop_concatenation
+from lfric_common import configurator
 from rose_picker_tool import get_rose_picker
 from templaterator import Templaterator
 
@@ -279,7 +279,6 @@ class LFRicBase(BafBase):
     def analyse(self):
         self.preprocess_x90()
         self.psyclone()
-        fparser_workaround_stop_concatenation(self.config)
         analyse(self.config, root_symbol=self._root_symbol,
                 ignore_mod_deps=['netcdf', 'MPI', 'yaxt', 'pfunit_mod',
                                  'xios', 'mod_wait'])

--- a/infrastructure/build/fab/lfric_common.py
+++ b/infrastructure/build/fab/lfric_common.py
@@ -75,32 +75,3 @@ def configurator(config, lfric_core_source: Path,
                                    '-output', feign_config_mod_fpath])
 
     find_source_files(config, source_root=config_dir)
-
-
-@step
-def fparser_workaround_stop_concatenation(config):
-    """
-    fparser can't handle string concat in a stop statement. This step is
-    a workaround.
-
-    https://github.com/stfc/fparser/issues/330
-
-    """
-    feign_path = None
-    for file_path in config.artefact_store[ArtefactSet.FORTRAN_BUILD_FILES]:
-        if file_path.name == 'feign_config_mod.f90':
-            feign_path = file_path
-            break
-    else:
-        raise RuntimeError("Could not find 'feign_config_mod.f90'.")
-
-    # rename "broken" version
-    broken_version = feign_path.with_suffix('.broken')
-    shutil.move(feign_path, broken_version)
-
-    # make fixed version
-    bad = "_config: '// &\n        'Unable to close temporary file'"
-    good = "_config: Unable to close temporary file'"
-
-    open(feign_path, 'wt').write(
-        open(broken_version, 'rt').read().replace(bad, good))


### PR DESCRIPTION
This removes the special handling of concatenation after fparser update: Issue #2.
