### PR TITLE
Update socrates and jules extraction and compilation flags

### DIFF
--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -123,7 +123,9 @@ class FabLFRicAtm(LFRicBase):
                                       '-I$source/shumlib/common/src',
                                       '-I$relative'],),
                       AddFlags(match="$source/science/*",
-                               flags=['-DLFRIC'])]
+                               flags=['-DLFRIC']),
+                      AddFlags(match="$source/science/socrates/aux/*",
+                               flags=['-I$source/science/socrates/aux'])]
         super().preprocess_fortran(path_flags=path_flags)
 
     def compile_fortran(self):

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -68,22 +68,29 @@ class FabLFRicAtm(LFRicBase):
     def find_source_files(self):
         """Based on $LFRIC_APPS_ROOT/build/extract/extract.cfg"""
 
-        extract = FcmExtract(self.lfric_apps_root / "build" / "extract" /
-                             "extract.cfg")
+        extract_cfg = [FcmExtract(self.lfric_apps_root / "build" / "extract" /
+                                  "extract.cfg"),
+                       FcmExtract(self.lfric_apps_root / "science" /
+                                  "socrates_interface" / "build" /
+                                  "extract.cfg"),
+                       FcmExtract(self.lfric_apps_root / "science" /
+                                  "jules_interface" / "build" /
+                                  "extract.cfg")]
 
         science_root = self.config.source_root / 'science'
         path_filters = []
-        for section, source_file_info in extract.items():
-            for (list_type, list_of_paths) in source_file_info:
-                if list_type == "exclude":
-                    path_filters.append(Exclude(science_root / section))
-                else:
-                    # Remove the 'src' which is the first part of the name
-                    new_paths = [i.relative_to(i.parents[-2])
-                                 for i in list_of_paths]
-                    for path in new_paths:
-                        path_filters.append(Include(science_root /
-                                                    section / path))
+        for extract in extract_cfg:
+            for section, source_file_info in extract.items():
+                for (list_type, list_of_paths) in source_file_info:
+                    if list_type == "exclude":
+                        path_filters.append(Exclude(science_root / section))
+                    else:
+                        # Remove the 'src' which is the first part of the name
+                        new_paths = [i.relative_to(i.parents[-2])
+                                     for i in list_of_paths]
+                        for path in new_paths:
+                            path_filters.append(Include(science_root /
+                                                        section / path))
         super().find_source_files(path_filters=path_filters)
 
     def get_rose_meta(self):

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -145,20 +145,21 @@ class FabLFRicAtm(LFRicBase):
         if fc.suite == "intel-classic":
             no_omp = "-qno-openmp"
             real8 = "-r8"
-            no_externals = "-warn noexternals"
+            no_externals = ["-warn", "noexternals"]
             # Some SOCRATES functions do not currently declare interfaces
             # This avoids a warning-turned-error about missing interfaces
         else:
             no_omp = "-fno-openmp"
             real8 = "-fdefault-real-8"
+            no_externals = []
         path_flags = [AddFlags(
             '$output/science/um/atmosphere/large_scale_precipitation/*',
             [no_omp]),
             AddFlags(match="$output/science/*", flags=[real8]),
             AddFlags(match="$output/science/socrates/radiance_core/*",
-                     flags=[no_externals]),
+                     flags=no_externals),
             AddFlags(match="$output/science/socrates/interface_core/*",
-                     flags=[no_externals])]
+                     flags=no_externals)]
         # TODO: A remove flag functionality based on profile option
         # and precision is needed
         if self._args.profile == 'full-debug':

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -132,6 +132,9 @@ class FabLFRicAtm(LFRicBase):
         if fc.suite == "intel-classic":
             no_omp = "-qno-openmp"
             real8 = "-r8"
+            no_externals = "-warn noexternals"
+            # Some SOCRATES functions do not currently declare interfaces
+            # This avoids a warning-turned-error about missing interfaces
         else:
             no_omp = "-fno-openmp"
             real8 = "-fdefault-real-8"
@@ -140,7 +143,8 @@ class FabLFRicAtm(LFRicBase):
             [no_omp]),
             AddFlags(match="$output/science/*", flags=[real8]),
             AddFlags(match="$output/science/socrates/aux/*",
-                     flags=['-I$source/science/socrates/aux']),]
+                     flags=['-I$source/science/socrates/aux']),
+            AddFlags(match="*/socrates/*",flags=[no_externals])]
         # TODO: A remove flag functionality based on profile option
         # and precision is needed
         if self._args.profile == 'full-debug':

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -149,9 +149,10 @@ class FabLFRicAtm(LFRicBase):
             '$output/science/um/atmosphere/large_scale_precipitation/*',
             [no_omp]),
             AddFlags(match="$output/science/*", flags=[real8]),
-            AddFlags(match="$output/science/socrates/aux/*",
-                     flags=['-I$source/science/socrates/aux', no_omp]),
-            AddFlags(match="*/socrates/*",flags=[no_externals])]
+            AddFlags(match="$output/science/socrates/radiance_core/*",
+                     flags=[no_externals]),
+            AddFlags(match="$output/science/socrates/interface_core/*",
+                     flags=[no_externals])]
         # TODO: A remove flag functionality based on profile option
         # and precision is needed
         if self._args.profile == 'full-debug':

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -140,7 +140,7 @@ class FabLFRicAtm(LFRicBase):
             real8 = "-fdefault-real-8"
         path_flags = [AddFlags(
             '$output/science/um/atmosphere/large_scale_precipitation/*',
-            [no_omp]),
+            [no_omp, no_externals]),
             AddFlags(match="$output/science/*", flags=[real8]),
             AddFlags(match="$output/science/socrates/aux/*",
                      flags=['-I$source/science/socrates/aux', no_omp]),

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -143,7 +143,7 @@ class FabLFRicAtm(LFRicBase):
             [no_omp]),
             AddFlags(match="$output/science/*", flags=[real8]),
             AddFlags(match="$output/science/socrates/aux/*",
-                     flags=['-I$source/science/socrates/aux']),
+                     flags=['-I$source/science/socrates/aux', no_omp]),
             AddFlags(match="*/socrates/*",flags=[no_externals])]
         # TODO: A remove flag functionality based on profile option
         # and precision is needed

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -140,7 +140,7 @@ class FabLFRicAtm(LFRicBase):
             real8 = "-fdefault-real-8"
         path_flags = [AddFlags(
             '$output/science/um/atmosphere/large_scale_precipitation/*',
-            [no_omp, no_externals]),
+            [no_omp]),
             AddFlags(match="$output/science/*", flags=[real8]),
             AddFlags(match="$output/science/socrates/aux/*",
                      flags=['-I$source/science/socrates/aux', no_omp]),

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -123,7 +123,7 @@ class FabLFRicAtm(LFRicBase):
                                       '-I$source/shumlib/common/src',
                                       '-I$relative'],),
                       AddFlags(match="$source/science/*",
-                               flags=['-DLFRIC']),
+                               flags=['-DLFRIC'])]
         super().preprocess_fortran(path_flags=path_flags)
 
     def compile_fortran(self):

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -69,13 +69,19 @@ class FabLFRicAtm(LFRicBase):
         """Based on $LFRIC_APPS_ROOT/build/extract/extract.cfg"""
 
         extract_cfg = [FcmExtract(self.lfric_apps_root / "build" / "extract" /
-                                  "extract.cfg"),
-                       FcmExtract(self.lfric_apps_root / "science" /
-                                  "socrates_interface" / "build" /
-                                  "extract.cfg"),
-                       FcmExtract(self.lfric_apps_root / "science" /
-                                  "jules_interface" / "build" /
                                   "extract.cfg")]
+
+        socrates_extract_cfg = self.lfric_apps_root / "science" /
+                               "socrates_interface" / "build" /
+                               "extract.cfg"
+        if socrates_extract_cfg.exists():
+           extract_cfg.append(FcmExtract(socrates_extract_cfg))
+
+        jules_extract_cfg = self.lfric_apps_root / "science" /
+                            "jules_interface" / "build" /
+                            "extract.cfg"
+        if jules_extract_cfg.exists():
+           extract_cfg.append(FcmExtract(jules_extract_cfg))
 
         science_root = self.config.source_root / 'science'
         path_filters = []

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -124,8 +124,6 @@ class FabLFRicAtm(LFRicBase):
                                       '-I$relative'],),
                       AddFlags(match="$source/science/*",
                                flags=['-DLFRIC']),
-                      AddFlags(match="$source/science/socrates/aux/*",
-                               flags=['-I$source/science/socrates/aux'])]
         super().preprocess_fortran(path_flags=path_flags)
 
     def compile_fortran(self):
@@ -140,7 +138,9 @@ class FabLFRicAtm(LFRicBase):
         path_flags = [AddFlags(
             '$output/science/um/atmosphere/large_scale_precipitation/*',
             [no_omp]),
-            AddFlags(match="$output/science/*", flags=[real8]),]
+            AddFlags(match="$output/science/*", flags=[real8]),
+            AddFlags(match="$output/science/socrates/aux/*",
+                     flags=['-I$source/science/socrates/aux']),]
         # TODO: A remove flag functionality based on profile option
         # and precision is needed
         if self._args.profile == 'full-debug':

--- a/applications/lfric_atm/fab_lfric_atm.py
+++ b/applications/lfric_atm/fab_lfric_atm.py
@@ -71,15 +71,15 @@ class FabLFRicAtm(LFRicBase):
         extract_cfg = [FcmExtract(self.lfric_apps_root / "build" / "extract" /
                                   "extract.cfg")]
 
-        socrates_extract_cfg = self.lfric_apps_root / "science" /
+        socrates_extract_cfg = (self.lfric_apps_root / "science" /
                                "socrates_interface" / "build" /
-                               "extract.cfg"
+                               "extract.cfg")
         if socrates_extract_cfg.exists():
            extract_cfg.append(FcmExtract(socrates_extract_cfg))
 
-        jules_extract_cfg = self.lfric_apps_root / "science" /
+        jules_extract_cfg = (self.lfric_apps_root / "science" /
                             "jules_interface" / "build" /
-                            "extract.cfg"
+                            "extract.cfg")
         if jules_extract_cfg.exists():
            extract_cfg.append(FcmExtract(jules_extract_cfg))
 

--- a/infrastructure/build/fab/lfric_common.py
+++ b/infrastructure/build/fab/lfric_common.py
@@ -43,7 +43,9 @@ def configurator(config, lfric_core_source: Path,
         rose_meta_conf,
         '-directory', config_dir,
         '-include_dirs', lfric_apps_source,
-        '-include_dirs', lfric_core_source])
+        '-include_dirs', lfric_core_source,
+        '-include_dirs', lfric_core_source / 'rose-meta',
+        '-include_dirs', lfric_apps_source / 'rose-meta'])
     rose_meta = config_dir / 'rose-meta.json'
 
     # build_config_loaders


### PR DESCRIPTION
This updates the extraction and build of socrates and jules for lfric_atm, based on the same update of this ticket: https://code.metoffice.gov.uk/trac/lfric_apps/ticket/539

The pipeline build is successful: https://git.nci.org.au/bom/ngm/lfric/lfric_atm-fab/-/commit/88db61f0f2a7991d79c995aa9c050e524dba136e