### PR TITLE
Added kernel extraction scripts for gravity_wave

### DIFF
--- a/applications/gravity_wave/fab_gravity_wave.py
+++ b/applications/gravity_wave/fab_gravity_wave.py
@@ -30,6 +30,11 @@ class FabGravityWave(LFRicBase):
             grab_folder(self.config, src=self.lfric_apps_root / dir,
                         dst_label='')
 
+        # Copy the optimisation scripts into a separate directory
+        dir = 'applications/gravity_wave/optimisation'
+        grab_folder(self.config, src=self.lfric_apps_root / dir,
+                    dst_label='optimisation')
+
     def get_rose_meta(self):
         return (self.lfric_apps_root / 'applications' / 'gravity_wave'
                 / 'rose-meta' / 'lfric-gravity_wave' / 'HEAD'

--- a/applications/gravity_wave/fab_gravity_wave_extract.py
+++ b/applications/gravity_wave/fab_gravity_wave_extract.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
+'''A FAB build script for gravity_wave. It relies on the FabBase class
+contained in the infrastructure directory.
+'''
+
+from fab_gravity_wave import FabGravityWave
+from extract_mixin import ExtractMixin
+
+
+class FabGravityWaveExtract(ExtractMixin, FabGravityWave):
+    '''This trivial class implements extraction for Gravity_wave. The mixin
+    Extract class overwrites the psyclone step (to insert its own
+    step of removing private declarations first).
+
+    There is no implementation here needed otherwise. The mixing inserts
+    the required phases, and overwrites the method with which to determine
+    the PSyclone script to use.
+
+    The only other important part here is __main__, which sets a different
+    fab workspace-name (and uses the class here).
+    '''
+
+
+# -----------------------------------------------------------------------------
+if __name__ == '__main__':
+
+    fab_gravity_wave = FabGravityWaveExtract(name="gravity_wave_extract",
+                                 root_symbol="gravity_wave")
+    fab_gravity_wave.build()

--- a/applications/gravity_wave/optimisation/extract/global.py
+++ b/applications/gravity_wave/optimisation/extract/global.py
@@ -1,0 +1,39 @@
+##############################################################################
+# Copyright (c) 2017,  Met Office, on behalf of HMSO and Queen's Printer
+# For further details please refer to the file LICENCE.original which you
+# should have received as part of this distribution.
+##############################################################################
+
+
+'''
+PSyclone transformation script for the LFRic (Dynamo0p3) API to apply
+colouring, OpenMP and redundant computation to the level-1 halo for
+the initialisation built-ins generically.
+
+'''
+
+from psyclone_tools import (redundant_computation_setval, colour_loops,
+                            openmp_parallelise_loops,
+                            view_transformed_schedule)
+from psyclone.domain.lfric import LFRicConstants, LFRicLoop
+from psyclone.domain.lfric.transformations import LFRicExtractTrans
+
+
+def trans(psy):
+    '''
+    Applies PSyclone colouring, OpenMP and redundant computation
+    transformations.
+
+    '''
+    extract = LFRicExtractTrans()
+    redundant_computation_setval(psy)
+    # colour_loops(psy)
+    # openmp_parallelise_loops(psy)
+    view_transformed_schedule(psy)
+    for invoke in psy.invokes.invoke_list:
+        schedule = invoke.schedule
+        for kern in schedule.walk(LFRicLoop):
+            try:
+                extract.apply(kern, {"create_driver": True})
+            except NotImplementedError:
+                pass


### PR DESCRIPTION
This PR added kernel extraction scripts for `gravity_wave` following `gungho_model` and copied the transformation scripts from `gungho_model`. 

The kernel extraction for `gravity_wave` is used for debugging cray compiler on Pawsey. This PR would be updated after #30 is merged. 