### PR TITLE
Modify root symbol

### DIFF
--- a/applications/lfricinputs/fab_lfricinputs.py
+++ b/applications/lfricinputs/fab_lfricinputs.py
@@ -11,6 +11,7 @@ contained in the infrastructure directory.
 
 import logging
 import os
+from typing import List, Union
 
 from fab.steps.grab.fcm import fcm_export
 from fab.steps.grab.folder import grab_folder
@@ -23,6 +24,19 @@ from fcm_extract import FcmExtract
 
 
 class FabLfricInputs(LFRicBase):
+    '''
+    This class builds LFRic inputs. Since LFRic inputs builds
+    different binaries in the same tree, it explicitly adds
+    the list of target symbols to build.
+
+    :param name: The name of the project directory.
+    :param root_symbol: The symbol of the main program(s) to be
+        created.
+    '''
+
+    def __init__(self, name: str, root_symbol: Union[str, List[str]]):
+        super().__init__(name)
+        self.set_root_symbol(root_symbol)
 
     def define_preprocessor_flags_step(self):
         super().define_preprocessor_flags_step()

--- a/doc/processing.rst
+++ b/doc/processing.rst
@@ -10,8 +10,9 @@ The full class documentation is at the end of this chapter.
 
 The constructor sets up ultimately the Fab ``BuildConfig`` for the build.
 It takes the name of the application as argument. The name of the application
-will be used when creating the name of the build directory (see XX),
-and it is also the default ``root_symbol`` if the script creates an exectuable.
+will be used when creating the name of the build directory
+and it is also the default ``root_symbol`` when analysing the source code
+if the script creates an executable (see :ref:`analyse_step`).
 
 The actual build is then started calling the ``build`` method
 of the created script. A typical outline of a BAF-based build script is
@@ -381,10 +382,19 @@ all Fortran files.
 .. automethod:: baf_base.BafBase.preprocess_fortran_step
     :noindex:
 
+.. _analyse_step:
+
 ``analyse_step``
 ~~~~~~~~~~~~~~~~
 This steps does the complete dependency analysis for the application.
 There is usually no reason for an application to overwrite this step.
+
+In case of creating a binary, the analyse step will use the root symbol,
+which defaults to the name of the application, but can be changed
+using ``set_root_symbol``. This implies that ``set_root_symbol``
+must be called before ``analyse_step`` is called, e.g. it can be called
+from any method called from the constructor (including defining and
+handling command line options).
 
 .. automethod:: baf_base.BafBase.analyse_step
     :noindex:

--- a/doc/processing.rst
+++ b/doc/processing.rst
@@ -9,10 +9,9 @@ build script can overwrite methods to customise the build process.
 The full class documentation is at the end of this chapter.
 
 The constructor sets up ultimately the Fab ``BuildConfig`` for the build.
-It takes two arguments - the name of the application, and
-optional the name of the root symbol for a binary to be compiled,
-i.e. the program name of a Fortran Program unit. If no
-root symbol is specified, the name will be used as root symbol.
+It takes the name of the application as argument. The name of the application
+will be used when creating the name of the build directory (see XX),
+and it is also the default ``root_symbol`` if the script creates an exectuable.
 
 The actual build is then started calling the ``build`` method
 of the created script. A typical outline of a BAF-based build script is

--- a/infrastructure/build/fab/baf_base.py
+++ b/infrastructure/build/fab/baf_base.py
@@ -457,32 +457,15 @@ class BafBase:
             ld = tr.get_tool(Category.LINKER, self.args.ld)
             self._tool_box.add_tool(ld)
 
-        try:
-            # If the user specified Fortran compiler flags in the
-            # environment variable FFLAGS, add them to the list of flags
-            # to be used by the Fortran compiler.
-            self._fortran_compiler_flags_commandline = \
-                os.environ.get("FFLAGS").split()
-        except AttributeError:
-            pass
-
-        try:
-            # If the user specified C compiler flags in the
-            # environment variable CFLAGS, add them to the list of flags
-            # to be used by the C compiler.
-            self._c_compiler_flags_commandline = \
-                os.environ.get("CFLAGS").split()
-        except AttributeError:
-            pass
-
-        try:
-            # If the user specified linker flags in the
-            # environment variable LDFLAGS, add them to the list of flags
-            # to be used by the linker.
-            self._linker_flags_commandline = \
-                os.environ.get("LDFLAGS").split()
-        except AttributeError:
-            pass
+        # If the user specified compiler flags in the
+        # environment variables CFLAGS, FFLAGS, LDFLAGS, add them to the
+        # list of flags to be used by the corresponding tools.
+        self._fortran_compiler_flags_commandline = \
+            os.environ.get("FFLAGS", "").split()
+        self._c_compiler_flags_commandline = \
+            os.environ.get("CFLAGS", "").split()
+        self._linker_flags_commandline = \
+            os.environ.get("LDFLAGS", "").split()
 
         if self.args.fflags:
             # If the user specified Fortran compiler flags, add them

--- a/infrastructure/build/fab/baf_base.py
+++ b/infrastructure/build/fab/baf_base.py
@@ -57,7 +57,7 @@ class BafBase:
         self._target = ""
         # Set the given name as root symbol, it can be set explicitly
         # using set_root_symbol()
-        self._root_symbol = name
+        self._root_symbol = [name]
 
         # The preprocessor flags to be used. One stores the common flags
         # (without path-specific component), the other the path-specific
@@ -115,19 +115,22 @@ class BafBase:
         label = f"{name}-{self.args.profile}-$compiler"
         return label
 
-    def set_root_symbol(self, root_symbol: str) -> None:
+    def set_root_symbol(self, root_symbol: Union[List[str], str]) -> None:
         '''Defines the root symbol. It defaults to the name given in
         the constructor.
 
         :param name: the root symbol to use when creating a binary
             (unused otherwise).
         '''
-        self._root_symbol = root_symbol
+        if isinstance(root_symbol, str):
+            self._root_symbol = [root_symbol]
+        else:
+            self._root_symbol = root_symbol
 
     @property
-    def root_symbol(self) -> str:
+    def root_symbol(self) -> List[str]:
         '''
-        :returns: the root symbol.
+        :returns: the list of root symbols.
         '''
         return self._root_symbol
 

--- a/infrastructure/build/fab/baf_base.py
+++ b/infrastructure/build/fab/baf_base.py
@@ -38,14 +38,11 @@ class BafBase:
         the name of the compiler will be added to it.
     :param link_target: what target should be created. Must be one of
         "executable" (default), "static-library", or "shared-library"
-    :param root_symbol: the name of the main program source file.
-        Needed when an executable is to be built.
     '''
     # pylint: disable=too-many-instance-attributes
     def __init__(self,
                  name: str,
-                 link_target: Optional[str] = "executable",
-                 root_symbol: Optional[str] = None):
+                 link_target: Optional[str] = "executable"):
         link_target = link_target.lower()
         valid_targets = ["executable", "static-library", "shared-library"]
         if link_target not in valid_targets:
@@ -58,6 +55,9 @@ class BafBase:
         # Save the name to use as library name (if required)
         self._name = name
         self._target = ""
+        # Set the given name as root symbol, it can be set explicitly
+        # using set_root_symbol()
+        self._root_symbol = name
 
         # The preprocessor flags to be used. One stores the common flags
         # (without path-specific component), the other the path-specific
@@ -90,11 +90,6 @@ class BafBase:
         if self._site_config:
             self._site_config.handle_command_line_options(self.args)
 
-        if root_symbol:
-            self._root_symbol = root_symbol
-        else:
-            self._root_symbol = name
-
         label = self.define_project_name(name=name)
         self._config = BuildConfig(tool_box=self._tool_box,
                                    project_label=label,
@@ -119,6 +114,15 @@ class BafBase:
         '''
         label = f"{name}-{self.args.profile}-$compiler"
         return label
+
+    def set_root_symbol(self, root_symbol: str) -> None:
+        '''Defines the root symbol. It defaults to the name given in
+        the constructor.
+
+        :param name: the root symbol to use when creating a binary
+            (unused otherwise).
+        '''
+        self._root_symbol = root_symbol
 
     @property
     def root_symbol(self) -> str:
@@ -681,5 +685,4 @@ if __name__ == "__main__":
     # This tests the BafBase class using the command line.
     logger = logging.getLogger("baf")
     logger.setLevel(logging.DEBUG)
-    baf_base = BafBase(name="command-line-test",
-                       root_symbol=None)
+    baf_base = BafBase(name="command-line-test")

--- a/infrastructure/build/fab/lfric_base.py
+++ b/infrastructure/build/fab/lfric_base.py
@@ -39,11 +39,18 @@ class LFRicBase(BafBase):
 
     :param str name: the name to be used for the workspace. Note that
         the name of the compiler will be added to it.
+    :param root_symbol: the name of the main program. Defaults to `name`
+        if not specified.
+
     '''
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, name: str):
+    def __init__(self, name: str, root_symbol: Optional[str] = None):
 
         super().__init__(name)
+        # If the user wants to overwrite the default root symbol (which
+        # is `name`):
+        if root_symbol:
+            self.set_root_symbol(root_symbol)
 
         this_file = Path(__file__)
         # The root directory of the LFRic Core

--- a/infrastructure/build/fab/lfric_base.py
+++ b/infrastructure/build/fab/lfric_base.py
@@ -39,12 +39,11 @@ class LFRicBase(BafBase):
 
     :param str name: the name to be used for the workspace. Note that
         the name of the compiler will be added to it.
-    :param Optional[str] root_symbol:
     '''
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, name: str, root_symbol: Optional[str] = None):
+    def __init__(self, name: str):
 
-        super().__init__(name, root_symbol=root_symbol)
+        super().__init__(name)
 
         this_file = Path(__file__)
         # The root directory of the LFRic Core
@@ -247,7 +246,8 @@ class LFRicBase(BafBase):
                         "infrastructure" / "build" / "psyclone" / "psydata"
                         / dir, dst_label='psydata')
 
-    def find_source_files_step(self,
+    def find_source_files_step(
+            self,
             path_filters: Optional[Iterable[Union[Exclude, Include]]] = None
             ) -> None:
         '''
@@ -339,7 +339,7 @@ class LFRicBase(BafBase):
         '''
         self.preprocess_x90_step()
         self.psyclone_step()
-        analyse(self.config, root_symbol=self._root_symbol,
+        analyse(self.config, root_symbol=self.root_symbol,
                 ignore_mod_deps=['netcdf', 'MPI', 'yaxt', 'pfunit_mod',
                                  'xios', 'mod_wait'])
 
@@ -435,5 +435,4 @@ if __name__ == "__main__":
     # This tests the LFRicBase class using the command line.
     logger = logging.getLogger('fab')
     logger.setLevel(logging.DEBUG)
-    lfric_base = LFRicBase(name="command-line-test",
-                           root_symbol=None)
+    lfric_base = LFRicBase(name="command-line-test")

--- a/infrastructure/build/fab/lfric_base.py
+++ b/infrastructure/build/fab/lfric_base.py
@@ -385,7 +385,7 @@ class LFRicBase(BafBase):
             PSyclone config file.
         :rtype: List[str]
         '''
-        return ["--config", self._psyclone_config]
+        return ["--config", str(self._psyclone_config)]
 
     def get_additional_psyclone_options(self) -> List[str]:
         '''

--- a/infrastructure/build/fab/lfric_base.py
+++ b/infrastructure/build/fab/lfric_base.py
@@ -39,12 +39,13 @@ class LFRicBase(BafBase):
 
     :param str name: the name to be used for the workspace. Note that
         the name of the compiler will be added to it.
-    :param root_symbol: the name of the main program. Defaults to `name`
-        if not specified.
+    :param root_symbol: the symbol (or list of symbols) of the main
+        programs. Defaults to the parameter `name` if not specified.
 
     '''
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, name: str, root_symbol: Optional[str] = None):
+    def __init__(self, name: str,
+                 root_symbol: Optional[Union[List[str], str]] = None):
 
         super().__init__(name)
         # If the user wants to overwrite the default root symbol (which


### PR DESCRIPTION
Fixes #69. It adds a method that an application can call to set the root symbol to use.
 